### PR TITLE
Template command improvements

### DIFF
--- a/cmd/template.go
+++ b/cmd/template.go
@@ -481,6 +481,62 @@ Examples:
 	},
 }
 
+var templateRemoveCmd = &cobra.Command{
+	Use:   "remove <n>",
+	Short: "Remove a template",
+	Long:  `Remove (delete) a template file from the templates directory.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmdutil.StartCommand(cmd)
+
+		ws, err := workspace.RequireWorkspace()
+		if err != nil {
+			if ctx.IsJSONOutput() {
+				return ctx.HandleError(err)
+			}
+			return err
+		}
+
+		name := args[0]
+		pathUtil := cmdutil.NewPathUtil(ws)
+		templatePath := pathUtil.JotDirJoin(filepath.Join("templates", name+".md"))
+
+		// Check if file exists
+		if _, err := cmdutil.ReadFileContent(templatePath); err != nil {
+			if ctx.IsJSONOutput() {
+				return ctx.HandleError(fmt.Errorf("template '%s' not found", name))
+			}
+			return fmt.Errorf("template '%s' not found", name)
+		}
+
+		err = os.Remove(templatePath)
+		if err != nil {
+			if ctx.IsJSONOutput() {
+				return ctx.HandleError(fmt.Errorf("failed to remove template: %w", err))
+			}
+			return fmt.Errorf("failed to remove template: %w", err)
+		}
+
+		if ctx.IsJSONOutput() {
+			response := struct {
+				Operation    string               `json:"operation"`
+				TemplateName string               `json:"template_name"`
+				Removed      bool                 `json:"removed"`
+				Metadata     cmdutil.JSONMetadata `json:"metadata"`
+			}{
+				Operation:    "template_remove",
+				TemplateName: name,
+				Removed:      true,
+				Metadata:     cmdutil.CreateJSONMetadata(cmd, true, ctx.StartTime),
+			}
+			return cmdutil.OutputJSON(response)
+		}
+
+		fmt.Printf("Template '%s' removed.\n", name)
+		return nil
+	},
+}
+
 // Helper function to count approved templates
 func countApproved(templates []template.Template) int {
 	count := 0
@@ -566,4 +622,5 @@ func init() {
 	templateCmd.AddCommand(templateApproveCmd)
 	templateCmd.AddCommand(templateViewCmd)
 	templateCmd.AddCommand(templateRenderCmd)
+	templateCmd.AddCommand(templateRemoveCmd)
 }

--- a/docs/commands/jot-template.md
+++ b/docs/commands/jot-template.md
@@ -142,12 +142,17 @@ The `new` subcommand:
 
 ## edit
 
-Modify an existing template in your editor.
+Modify an existing template in your editor, or overwrite it with content from stdin.
 
 ### Usage
 
 ```bash
-jot template edit <name> [options]
+# Edit in your editor
+jot template edit <name>
+
+# Overwrite with piped content (no editor)
+echo "new template content" | jot template edit <name>
+cat template.md | jot template edit <name>
 ```
 
 ### Arguments
@@ -158,21 +163,29 @@ jot template edit <name> [options]
 
 ### Examples
 
-#### Edit existing template
+#### Edit existing template in your editor
 
 ```bash
 jot template edit meeting
 ```
 
-Opens the meeting template in your editor. If the template contains shell commands and you modify them, the template will need re-approval.
+#### Overwrite a template with piped content
+
+```bash
+echo "---\ndestination: inbox.md\n---\n# New Template" | jot template edit meeting
+cat my-template.md | jot template edit meeting
+```
+
+If you pipe content to `jot template edit`, the template will be overwritten with the piped content and the editor will not be launched.
 
 ### What Happens
 
 The `edit` subcommand:
-1. **Opens template file** in your editor
-2. **Checks for modifications** after editing
-3. **Invalidates approval** if shell commands changed
-4. **Prompts for re-approval** if needed
+1. **If stdin is a pipe**, reads content from stdin and overwrites the template file (no editor is launched)
+2. **Otherwise**, opens the template file in your editor
+3. **Checks for modifications** after editing
+4. **Invalidates approval** if shell commands changed
+5. **Prompts for re-approval** if needed
 
 ## approve
 

--- a/docs/commands/jot-template.md
+++ b/docs/commands/jot-template.md
@@ -333,6 +333,44 @@ The `render` subcommand:
 3. **Displays rendered output** with dynamic content
 4. **Respects security settings** and approval requirements
 
+## remove
+
+Remove (delete) a template file from the templates directory.
+
+### Usage
+
+```bash
+jot template remove <name> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `name`   | Name of the template to remove |
+
+### Examples
+
+#### Remove a template
+
+```bash
+jot template remove meeting
+```
+
+#### Remove a template with JSON output
+
+```bash
+jot template remove meeting --json
+```
+
+### What Happens
+
+The `remove` subcommand:
+1. **Checks if the template file exists** in `.jot/templates/`
+2. **Deletes the template file** if found
+3. **Prints a confirmation message** (or outputs JSON if `--json` is used)
+4. **Returns an error** if the template does not exist or cannot be deleted
+
 ## Template Structure
 
 Templates consist of:


### PR DESCRIPTION
## Description
- Allow use of stdin to give new content for a template
- Add a `jot template remove` subcommand

## Problem
For an  editor plugin, `EDITOR` env var may not work, so this allows a bypass for tooling.

## Testing

```bash
echo "hello world" | jot template edit foo
```

```bash
jot template remove foo
```

## Checklist
- [x] Code follows project style guidelines
- [ ] Tests added/updated for new functionality
- [x] Documentation updated if needed
- [ ] All tests pass locally (`make test`)
- [x] Code passes linting (`make lint`)

## Additional Notes
Any other information that would be helpful for reviewers.
